### PR TITLE
Fix missing module check_os

### DIFF
--- a/tribler.spec
+++ b/tribler.spec
@@ -92,6 +92,7 @@ install -m644 Tribler/Main/Build/Ubuntu/tribler_big.xpm %{buildroot}/usr/share/p
 install -m755 debian/bin/tribler %{buildroot}/usr/bin
 install -m644 logger.conf %{buildroot}/usr/share/tribler/
 install -m644 run_tribler.py %{buildroot}/usr/share/tribler/
+install -m644 check_os.py %{buildroot}/usr/share/tribler/
 cp -r twisted %{buildroot}/usr/share/tribler
 
 %files


### PR DESCRIPTION
When launching tribler on Fedora 27, module check_os may be missing.

`Traceback (most recent call last):
  File "run_tribler.py", line 6, in <module>
    from check_os import check_environment, check_free_space, error_and_exit, setup_gui_logging, \
ImportError: No module named check_os`

See also upstream patch for Debian : https://github.com/Tribler/tribler/pull/3124/files